### PR TITLE
Templatize server names

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/jsoriano/kube2lb",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.6",
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",

--- a/examples/caddy/Caddyfile.tpl
+++ b/examples/caddy/Caddyfile.tpl
@@ -2,11 +2,14 @@
 {{ $services := .Services }}
 {{ $domain := .Domain }}
 {{ range $i, $service := $services }}
-http://{{ $service.Name }}.{{ $service.Namespace }}.svc.{{ $domain }}:{{ $service.Port }} {
+{{ range $j, $serverName := ServerNames $service $domain }}
+http://{{ $serverName }}:{{ $service.Port }} {
 	log / stdout "{host} {remote} - [{when}] \"{method} {path} {proto}\" {status} {size} \"{>Referer}\" \"{>User-Agent}\" \"{latency}\""
 	proxy /{{ range $i, $node := $nodes }} {{ $node }}:{{ $service.NodePort }}{{ end }} {
 		policy least_conn
 		proxy_header Host {host}
 	}
 }
+
+{{ end }}
 {{ end }}

--- a/examples/caddy/Caddyfile.tpl
+++ b/examples/caddy/Caddyfile.tpl
@@ -1,8 +1,8 @@
-{{ $nodes := .Nodes }}
-{{ $services := .Services }}
-{{ $domain := .Domain }}
-{{ range $i, $service := $services }}
-{{ range $j, $serverName := ServerNames $service $domain }}
+{{ $nodes := .Nodes -}}
+{{ $services := .Services -}}
+{{ $domain := .Domain -}}
+{{ range $i, $service := $services -}}
+{{ range $j, $serverName := ServerNames $service $domain -}}
 http://{{ $serverName }}:{{ $service.Port }} {
 	log / stdout "{host} {remote} - [{when}] \"{method} {path} {proto}\" {status} {size} \"{>Referer}\" \"{>User-Agent}\" \"{latency}\""
 	proxy /{{ range $i, $node := $nodes }} {{ $node }}:{{ $service.NodePort }}{{ end }} {
@@ -10,6 +10,5 @@ http://{{ $serverName }}:{{ $service.Port }} {
 		proxy_header Host {host}
 	}
 }
-
-{{ end }}
-{{ end }}
+{{ end -}}
+{{ end -}}

--- a/examples/caddy/entrypoint.sh
+++ b/examples/caddy/entrypoint.sh
@@ -12,5 +12,5 @@ _term() {
 trap _term SIGTERM SIGINT
 
 caddy -conf=$CONFFILE -pidfile=$PIDFILE -log=stdout &
-kube2lb -apiserver=$APISERVER -kubecfg=$KUBECFG -template=$TEMPLATE -config=$CONFFILE -domain=$DOMAIN -notify=pidfile:SIGUSR1:$PIDFILE &
+kube2lb -apiserver="$APISERVER" -kubecfg="$KUBECFG" -template="$TEMPLATE" -server-name-templates="$SERVER_NAME_TEMPLATES" -config="$CONFFILE" -domain="$DOMAIN" -notify="pidfile:SIGUSR1:$PIDFILE" &
 wait $!

--- a/examples/haproxy/entrypoint.sh
+++ b/examples/haproxy/entrypoint.sh
@@ -20,5 +20,5 @@ frontend nothing
 " > $CONFFILE
 
 haproxy -f $CONFFILE -p $PIDFILE
-kube2lb -apiserver=$APISERVER -kubecfg=$KUBECFG -template=$TEMPLATE -config=$CONFFILE -domain=$DOMAIN -notify=command:"haproxy -f $CONFFILE -p $PIDFILE -sf \$(cat $PIDFILE)" &
+kube2lb -apiserver="$APISERVER" -kubecfg="$KUBECFG" -template="$TEMPLATE" -server-name-templates="$SERVER_NAME_TEMPLATES" -config="$CONFFILE" -domain="$DOMAIN" -notify=command:"haproxy -f $CONFFILE -p $PIDFILE -sf \$(cat $PIDFILE)" &
 wait $!

--- a/examples/haproxy/haproxy.cfg.tpl
+++ b/examples/haproxy/haproxy.cfg.tpl
@@ -1,8 +1,7 @@
-{{ $nodes := .Nodes }}
-{{ $services := .Services }}
-{{ $domain := .Domain }}
-{{ $ports := .Ports }}
-
+{{ $nodes := .Nodes -}}
+{{ $services := .Services -}}
+{{ $domain := .Domain -}}
+{{ $ports := .Ports -}}
 global
 	log 127.0.0.1   local0
 	log 127.0.0.1   local1 notice
@@ -20,18 +19,18 @@ defaults
 {{ range $i, $port := $ports }}
 frontend frontend_{{ $port }}
 	bind *:{{ $port }}
-{{ range $i, $service := $services }}
-{{ if eq $service.Port $port }}
-{{ $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+{{- range $i, $service := $services }}
+{{- if eq $service.Port $port }}
+{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
 	{{ range $serverName := ServerNames $service $domain }}
 	acl svc_{{ $label }} hdr(host) -i {{ $serverName }}{{ end }}
 	use_backend backend_{{ $label }} if svc_{{ $label }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}
 {{ end }}
 
-{{ range $i, $service := $services }}
-{{ $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+{{- range $i, $service := $services }}
+{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
 backend backend_{{ $label }}
 	balance leastconn
 	option httpclose

--- a/examples/haproxy/haproxy.cfg.tpl
+++ b/examples/haproxy/haproxy.cfg.tpl
@@ -6,7 +6,7 @@
 global
 	log 127.0.0.1   local0
 	log 127.0.0.1   local1 notice
-	maxconn 4096
+	maxconn 65536
 	daemon
 
 defaults
@@ -23,7 +23,8 @@ frontend frontend_{{ $port }}
 {{ range $i, $service := $services }}
 {{ if eq $service.Port $port }}
 {{ $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
-	acl svc_{{ $label }} hdr(host) -i {{ $service.Name }}.{{ $service.Namespace }}.svc.{{ $domain }}
+	{{ range $serverName := ServerNames $service $domain }}
+	acl svc_{{ $label }} hdr(host) -i {{ $serverName }}{{ end }}
 	use_backend backend_{{ $label }} if svc_{{ $label }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Add a parameter to provision a list of templates to generate server names. It allows to expose kubernetes services with different DNS schemas.

It uses go 1.6 to trim spaces in templates.
