### PR TITLE
Added example for haproxy-docker-wrapper

### DIFF
--- a/examples/haproxy-docker-wrapper/Dockerfile
+++ b/examples/haproxy-docker-wrapper/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+
+MAINTAINER Jaime Soriano Pastor <jsoriano@tuenti.com>
+
+RUN apt-get update && \
+	apt-get install -y curl && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY haproxy.cfg.tpl /etc/kube2lb/haproxy.cfg.tpl
+COPY kube2lb /usr/local/bin/kube2lb
+COPY entrypoint.sh /entrypoint.sh
+
+ENV SYSLOG "127.0.0.1:514"
+ENV HAPROXY_WRAPPER_CONTROL "127.0.0.1:15000"
+ENV HAPROXY_STATS_BIND "127.0.0.1:9090"
+ENV TEMPLATE /etc/kube2lb/haproxy.cfg.tpl
+
+EXPOSE 80
+
+CMD ["/entrypoint.sh"]

--- a/examples/haproxy-docker-wrapper/Makefile
+++ b/examples/haproxy-docker-wrapper/Makefile
@@ -1,0 +1,12 @@
+TAG:=kube2lb:haproxy-docker-wrapper
+
+all: kube2lb
+	docker build --tag=$(TAG) .
+
+kube2lb:
+	make -C ../..
+	cp ../../kube2lb .
+
+clean:
+	rm -f kube2lb
+	docker rmi $(TAG) || true

--- a/examples/haproxy-docker-wrapper/README.md
+++ b/examples/haproxy-docker-wrapper/README.md
@@ -1,0 +1,12 @@
+# How to use this example
+
+```
+make
+docker run -it --rm \
+	-e KUBECFG=/etc/kube/conf \
+	-e DOMAIN=cluster.local \
+	-v ~/.kube/config:/etc/kube/conf:ro \
+	kube2lb:haproxy-docker-wrapper
+```
+
+To be used with [haproxy-docker-wrapper](https://github.com/tuenti/haproxy-docker-wrapper).

--- a/examples/haproxy-docker-wrapper/entrypoint.sh
+++ b/examples/haproxy-docker-wrapper/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CONFFILE=/usr/local/etc/haproxy/haproxy.cfg
+
+echo "
+global
+	daemon
+
+frontend nothing
+	bind :80
+" > $CONFFILE
+
+sed -i $TEMPLATE \
+	-e "s/__HAPROXY_STATS_BIND__/$HAPROXY_STATS_BIND/" \
+	-e "s/__SYSLOG__/$SYSLOG/"
+
+exec kube2lb -apiserver="$APISERVER" -kubecfg="$KUBECFG" -template="$TEMPLATE" -server-name-templates="$SERVER_NAME_TEMPLATES" -config="$CONFFILE" -domain="$DOMAIN" -notify=command:"curl -s http://$HAPROXY_WRAPPER_CONTROL/reload"

--- a/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
+++ b/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
@@ -1,0 +1,63 @@
+{{ $nodes := .Nodes -}}
+{{ $services := .Services -}}
+{{ $domain := .Domain -}}
+{{ $ports := .Ports -}}
+global
+	log __SYSLOG__   local0 notice
+	maxconn 65536
+	daemon
+
+defaults
+	log        global
+	mode       http
+	option     httplog
+	option     dontlognull
+	option     forwardfor
+	http-reuse aggressive
+	retries    3
+	option     redispatch
+	timeout connect 3s
+	timeout client  200s
+	timeout client  30s
+	timeout server  200s
+	timeout tunnel  1h
+
+frontend stats-frontend
+	mode http
+	bind __HAPROXY_STATS_BIND__
+	default_backend stats-backend
+
+backend stats-backend
+	mode http
+	stats enable
+	stats show-node
+	stats refresh 60s
+	stats uri /
+
+{{ range $i, $port := $ports }}
+frontend frontend_{{ $port }}
+	bind *:{{ $port }}
+{{- range $i, $service := $services }}
+{{- if eq $service.Port $port }}
+{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+	{{ range $serverName := ServerNames $service $domain }}
+	{{- if $serverName.IsRegexp }}
+	acl svc_{{ $label }} hdr_reg(host) {{ $serverName.Regexp }}
+	{{- else }}
+	acl svc_{{ $label }} hdr(host) -i {{ $serverName }}
+	{{- end }}
+	{{- end }}
+
+	use_backend backend_{{ $label }} if svc_{{ $label }}
+{{- end }}
+{{- end }}
+{{ end }}
+
+{{- range $i, $service := $services }}
+{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+backend backend_{{ $label }}
+	balance leastconn
+	option http-server-close
+	{{ range $i, $node := $nodes }}
+	server {{ EscapeNode $node }} {{ $node }}:{{ $service.NodePort }} check{{ end }}
+{{ end }}


### PR DESCRIPTION
These changes add the code needed to generate a docker with kube2lb and an haproxy template, but without haproxy.
