### PR TITLE
Port modes can be specified using annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ make
 
 ## Configuration details
 
+### Kubeconfig
+
 Kubernetes connections to the API are done using the same libraries as other
 tools as `kubectl` or `kube2sky` and following similar principles.
 
@@ -57,6 +59,8 @@ Configuration is taken in this order:
 1. Configuration file (`-kubecfg` flag, api server endpoint can be overriden
    with `-apiserver`)
 1. In cluster configuration, useful if `kube2lb` is deployed in a pod
+
+### Server names
 
 Templates receive the list of nodes, services and the domain passed with the
 `-domain` flag.
@@ -94,8 +98,35 @@ acl svc_{{ $label }} hdr(host) -i {{ $serverName }}{{- end }}
 {{- end }}
 ```
 
+### Port modes
+
+Load balancers use to differenciate TCP and HTTP connections, for HTTP
+connections they have additional features as the possibility of choosing a
+backend depending on an specific HTTP header. `kube2lb` allows to declare
+different modes for some ports.
+
+Default mode can be changed with the `-default-port-mode` flag, it is 
+http by default.
+
+An annotation can be used to declare different modes. e.g:
+```
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kube2lb/port-mode: |
+      { "mysql": "tcp" }
+...
+```
+The annotation must be a string to string map represented as valid JSON, with
+the port name as key and the mode as value. Ports must declare their names
+in order to use this feature.
+
+### Notifiers
+
 `kube2lb` can be used with any service that is configured with configuration
-files and can do online configuration reload.
+files and can do online configuration reload. To notify the service that it
+must reload its configuration a notifier needs to be configured.
 
 By now these notifier definitions can be used:
 

--- a/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
+++ b/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
@@ -35,11 +35,12 @@ backend stats-backend
 	stats uri /
 
 {{ range $i, $port := $ports }}
-frontend frontend_{{ $port }}
-	bind *:{{ $port }}
+frontend frontend_{{ $port.String }}
+	bind *:{{ $port.Port }}
 {{- range $i, $service := $services }}
-{{- if eq $service.Port $port }}
-{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+{{- if eq $service.Port.String $port.String }}
+{{- $label := printf "%s_%s_%s" $service.Name $service.Namespace $service.Port }}
+{{- if eq $port.Mode "http" }}
 	{{ range $serverName := ServerNames $service $domain }}
 	{{- if $serverName.IsRegexp }}
 	acl svc_{{ $label }} hdr_reg(host) {{ $serverName.Regexp }}
@@ -47,17 +48,27 @@ frontend frontend_{{ $port }}
 	acl svc_{{ $label }} hdr(host) -i {{ $serverName }}
 	{{- end }}
 	{{- end }}
-
 	use_backend backend_{{ $label }} if svc_{{ $label }}
+{{- end }}
+{{- if eq $port.Mode "tcp" }}
+	mode tcp
+
+	use_backend backend_{{ $label }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{ end }}
 
 {{- range $i, $service := $services }}
-{{- $label := printf "%s_%s_%d" $service.Name $service.Namespace $service.Port }}
+{{- $label := printf "%s_%s_%s" $service.Name $service.Namespace $service.Port }}
 backend backend_{{ $label }}
 	balance leastconn
+{{- if eq $service.Port.Mode "http" }}
 	option http-server-close
+{{- end }}
+{{- if eq $service.Port.Mode "tcp" }}
+	mode tcp
+{{- end }}
 	{{ range $i, $node := $nodes }}
 	server {{ EscapeNode $node }} {{ $node }}:{{ $service.NodePort }} check{{ end }}
 {{ end }}

--- a/templates.go
+++ b/templates.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -67,17 +68,27 @@ func initServerNameTemplates() (err error) {
 	return err
 }
 
+type PortSpec struct {
+	Port     int
+	Mode     string
+	Protocol string
+}
+
+func (s PortSpec) String() string {
+	return fmt.Sprintf("%d_%s_%s", s.Port, s.Protocol, s.Mode)
+}
+
 type ServiceInformation struct {
 	Name      string
 	Namespace string
-	Port      int
+	Port      PortSpec
 	NodePort  int
 	External  []string
 }
 
 type ClusterInformation struct {
 	Services []ServiceInformation
-	Ports    []int
+	Ports    []PortSpec
 	Nodes    []string
 	Domain   string
 }
@@ -131,6 +142,8 @@ func (t *Template) Execute(info *ClusterInformation) error {
 	funcMap := template.FuncMap{
 		"ServerNames": generateServerNames,
 		"EscapeNode":  nodeNameReplacer.Replace,
+		"ToUpper":     strings.ToUpper,
+		"ToLower":     strings.ToLower,
 	}
 
 	// template.Execute will use the base name of t.Source


### PR DESCRIPTION
For example haproxy supports HTTP and TCP modes, this change
adds support to have services with different port modes using
the same template.
