### PR TITLE
Fix ignored svc changes

### DIFF
--- a/comparators.go
+++ b/comparators.go
@@ -26,20 +26,20 @@ import (
 
 type EqualFunc func(a, b runtime.Object) (bool, error)
 
-func EqualUIDs(a, b runtime.Object) (bool, error) {
+func EqualNames(a, b runtime.Object) (bool, error) {
 	accessor := meta.NewAccessor()
 
-	UIDA, err := accessor.UID(a)
+	nameA, err := accessor.Name(a)
 	if err != nil {
 		return false, err
 	}
 
-	UIDB, err := accessor.UID(b)
+	nameB, err := accessor.Name(b)
 	if err != nil {
 		return false, err
 	}
 
-	return UIDA == UIDB, nil
+	return nameA == nameB, nil
 }
 
 func getEndpointsUIDs(e *v1.Endpoints) map[string]bool {

--- a/comparators.go
+++ b/comparators.go
@@ -24,8 +24,6 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 )
 
-type EqualFunc func(a, b runtime.Object) (bool, error)
-
 func EqualNames(a, b runtime.Object) (bool, error) {
 	accessor := meta.NewAccessor()
 
@@ -40,6 +38,22 @@ func EqualNames(a, b runtime.Object) (bool, error) {
 	}
 
 	return nameA == nameB, nil
+}
+
+func EqualResourceVersions(a, b runtime.Object) (bool, error) {
+	accessor := meta.NewAccessor()
+
+	versionA, err := accessor.ResourceVersion(a)
+	if err != nil {
+		return false, err
+	}
+
+	versionB, err := accessor.ResourceVersion(b)
+	if err != nil {
+		return false, err
+	}
+
+	return versionA == versionB, nil
 }
 
 func getEndpointsUIDs(e *v1.Endpoints) map[string]bool {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -256,7 +256,7 @@ func (c *KubernetesClient) Watch() error {
 	c.serviceStore = ServiceStore{NewLocalStore()}
 	c.endpointsStore = EndpointsStore{NewLocalStore()}
 
-	updateStore := func(s Store, e watch.Event, equal EqualFunc) {
+	updateStore := func(s Store, e watch.Event) {
 		if e.Object == nil {
 			return
 		}
@@ -268,26 +268,24 @@ func (c *KubernetesClient) Watch() error {
 		switch e.Type {
 		case watch.Added:
 			s.Update(e.Object)
-			updater.Signal()
 		case watch.Modified:
 			old := s.Update(e.Object)
 			if old == nil {
 				log.Println("Modified unknown object, this shouldn't happen")
-			} else if equal != nil {
-				eq, err := equal(old, e.Object)
-				if err != nil {
-					log.Println(err)
-					return
-				}
-				if eq {
-					return
-				}
+				break
 			}
-			updater.Signal()
+			eq, err := s.Equal(old, e.Object)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if eq {
+				return
+			}
 		case watch.Deleted:
 			s.Delete(e.Object)
-			updater.Signal()
 		}
+		updater.Signal()
 	}
 
 	var more bool
@@ -295,11 +293,11 @@ func (c *KubernetesClient) Watch() error {
 	for {
 		select {
 		case e, more = <-c.nodeWatcher.ResultChan():
-			updateStore(c.nodeStore, e, EqualNames)
+			updateStore(c.nodeStore, e)
 		case e, more = <-c.serviceWatcher.ResultChan():
-			updateStore(c.serviceStore, e, nil)
+			updateStore(c.serviceStore, e)
 		case e, more = <-c.endpointsWatcher.ResultChan():
-			updateStore(c.endpointsStore, e, EqualEndpoints)
+			updateStore(c.endpointsStore, e)
 		}
 
 		// Used in tests to know when events have been processed

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -273,7 +273,7 @@ func (c *KubernetesClient) Watch() error {
 			old := s.Update(e.Object)
 			if old == nil {
 				log.Println("Modified unknown object, this shouldn't happen")
-			} else {
+			} else if equal != nil {
 				eq, err := equal(old, e.Object)
 				if err != nil {
 					log.Println(err)
@@ -295,9 +295,9 @@ func (c *KubernetesClient) Watch() error {
 	for {
 		select {
 		case e, more = <-c.nodeWatcher.ResultChan():
-			updateStore(c.nodeStore, e, EqualUIDs)
+			updateStore(c.nodeStore, e, EqualNames)
 		case e, more = <-c.serviceWatcher.ResultChan():
-			updateStore(c.serviceStore, e, EqualUIDs)
+			updateStore(c.serviceStore, e, nil)
 		case e, more = <-c.endpointsWatcher.ResultChan():
 			updateStore(c.endpointsStore, e, EqualEndpoints)
 		}

--- a/localstore.go
+++ b/localstore.go
@@ -28,6 +28,7 @@ import (
 type Store interface {
 	Delete(runtime.Object) runtime.Object
 	Update(runtime.Object) runtime.Object
+	Equal(runtime.Object, runtime.Object) (bool, error)
 }
 
 type LocalStore struct {
@@ -40,6 +41,10 @@ func NewLocalStore() *LocalStore {
 	return &LocalStore{
 		Objects: make(map[string]runtime.Object),
 	}
+}
+
+func (s *LocalStore) Equal(o runtime.Object, n runtime.Object) (bool, error) {
+	return EqualResourceVersions(o, n)
 }
 
 func (s *LocalStore) Update(o runtime.Object) runtime.Object {
@@ -66,6 +71,11 @@ func (s *LocalStore) Delete(o runtime.Object) runtime.Object {
 
 type NodeStore struct {
 	*LocalStore
+}
+
+func (s NodeStore) Equal(o runtime.Object, n runtime.Object) (bool, error) {
+	// Not completelly accurate, but by now we are only using node names
+	return EqualNames(o, n)
 }
 
 func (s *NodeStore) GetNames() []string {
@@ -101,6 +111,10 @@ func (s *ServiceStore) List() ([]*v1.Service, error) {
 
 type EndpointsStore struct {
 	*LocalStore
+}
+
+func (s EndpointsStore) Equal(o runtime.Object, n runtime.Object) (bool, error) {
+	return EqualEndpoints(o, n)
 }
 
 func (s *EndpointsStore) List() ([]*v1.Endpoints, error) {


### PR DESCRIPTION
Fixes regression introduced in 2.1.0 that made kube2lb ignore changes in services.

This PR also includes some refactorization to add a method to each store to compare objects of its kind, and changes in tests to help preventing these regressions.