### PR TITLE
Ephemeral ports sanity check

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,6 +13,10 @@
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
+			"ImportPath": "github.com/achanda/go-sysctl",
+			"Rev": "6be7678c45d2052640e72060e4f5db6165b1ecab"
+		},
+		{
 			"ImportPath": "github.com/blang/semver",
 			"Comment": "v3.0.1",
 			"Rev": "31b736133b98f26d5e078ec9eb591666edfd091f"

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Tuenti Technologies S.L. All rights reserved.
+Copyright 2017 Tuenti Technologies S.L. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -209,6 +209,12 @@ func (c *KubernetesClient) getServices() ([]ServiceInformation, error) {
 			if len(endpointsPortsMap) == 0 {
 				log.Printf("Couldn't find endpoints for %s in %s?", s.Name, s.Namespace)
 				continue
+			}
+
+			err := ephemeralPortsRange.ValidateService(s)
+			if err != nil {
+				log.Printf("Service validation failed: %s", err)
+				break
 			}
 
 			for _, port := range s.Spec.Ports {

--- a/sanitychecks.go
+++ b/sanitychecks.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 Tuenti Technologies S.L. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/achanda/go-sysctl"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	ephemeralPortsRangeSysKey = "net.ipv4.ip_local_port_range"
+)
+
+type ServiceValidator interface {
+	ValidateService(*v1.Service) error
+}
+
+var (
+	ephemeralPortsRange *EphemeralPortsRange
+)
+
+type EphemeralPortsRange struct {
+	check    bool
+	LowPort  int32
+	HighPort int32
+}
+
+// Provide the range as a String
+func (r EphemeralPortsRange) String() string {
+	return fmt.Sprintf("%d->%d", r.LowPort, r.HighPort)
+}
+
+// Return error if any of the ports is in the ephemeral ports range, otherwise return nil (also if the check is disabled)
+func (r EphemeralPortsRange) ValidateService(s *v1.Service) error {
+	// Check is disabled
+	if !r.check {
+		return nil
+	}
+
+	for _, port := range s.Spec.Ports {
+		// Port found in range
+		if (port.Port >= r.LowPort) && (port.Port <= r.HighPort) {
+			return fmt.Errorf("Service %s in %s Service Port %d is in the ephemral ports range (%s), skipping it. Please check your configuration!", s.Name, s.Namespace, port.Port, r)
+		}
+	}
+	// None of the ports in range
+	return nil
+}
+
+// Retrieve the data from sysctl and return the values, disable the check if unsuccessful and log
+func initEphemeralPortsRangeCheck() *EphemeralPortsRange {
+	var l, h int32
+	r, err := sysctl.Get(ephemeralPortsRangeSysKey)
+	if err != nil {
+		log.Printf("Error reading %s from sysctl: %s, skipping ephemeral ports range checks", ephemeralPortsRangeSysKey, err)
+		return &EphemeralPortsRange{check: false, LowPort: 0, HighPort: 0}
+	}
+
+	fmt.Sscanf(r, "%d %d", &l, &h)
+	return &EphemeralPortsRange{check: true, LowPort: l, HighPort: h}
+}
+
+func init() {
+	ephemeralPortsRange = initEphemeralPortsRangeCheck()
+}

--- a/sanitychecks_test.go
+++ b/sanitychecks_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2017 Tuenti Technologies S.L. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/intstr"
+)
+
+func TestOnePortInRange(t *testing.T) {
+	r := EphemeralPortsRange{check: true, LowPort: 20000, HighPort: 40000}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo", Port: 20001, TargetPort: intstr.FromInt(20001),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err == nil {
+		t.Fatalf("Port is in range and check enabled, should return err")
+	}
+}
+
+func TestOnePortNotInRange(t *testing.T) {
+	r := EphemeralPortsRange{check: true, LowPort: 20000, HighPort: 40000}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo", Port: 19999, TargetPort: intstr.FromInt(19999),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err != nil {
+		t.Fatalf("Port is not range and check enabled, should return nil")
+	}
+}
+
+func TestMultiPortInRange(t *testing.T) {
+	r := EphemeralPortsRange{check: true, LowPort: 20000, HighPort: 40000}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo1", Port: 20001, TargetPort: intstr.FromInt(20001),
+				},
+				{
+					Name: "foo2", Port: 20002, TargetPort: intstr.FromInt(20002),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err == nil {
+		t.Fatalf("Ports are in range and check enabled, should return err")
+	}
+}
+
+func TestMultiPortAllNotInRange(t *testing.T) {
+	r := EphemeralPortsRange{check: true, LowPort: 20000, HighPort: 40000}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo1", Port: 19998, TargetPort: intstr.FromInt(19998),
+				},
+				{
+					Name: "foo2", Port: 19999, TargetPort: intstr.FromInt(19999),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err != nil {
+		t.Fatalf("Ports are not in range and check enabled, should return nil")
+	}
+}
+
+func TestMultiPortOneInRange(t *testing.T) {
+	r := EphemeralPortsRange{check: true, LowPort: 20000, HighPort: 40000}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo1", Port: 20001, TargetPort: intstr.FromInt(20001),
+				},
+				{
+					Name: "foo2", Port: 19999, TargetPort: intstr.FromInt(19999),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err == nil {
+		t.Fatalf("One port is in range and check enabled, should return err")
+	}
+}
+
+func TestSanityCheckDisabled(t *testing.T) {
+	r := EphemeralPortsRange{check: false, LowPort: 0, HighPort: 0}
+	s := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{SelfLink: "/service/1", Name: "service1", Namespace: "test", ResourceVersion: "3"},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name: "foo1", Port: 20001, TargetPort: intstr.FromInt(20001),
+				},
+				{
+					Name: "foo2", Port: 19999, TargetPort: intstr.FromInt(19999),
+				},
+			},
+		},
+	}
+
+	err := r.ValidateService(s)
+	if err != nil {
+		t.Fatalf("Checks are disabled, should return nil")
+	}
+}

--- a/vendor/github.com/achanda/go-sysctl/.gitignore
+++ b/vendor/github.com/achanda/go-sysctl/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/achanda/go-sysctl/.travis.yml
+++ b/vendor/github.com/achanda/go-sysctl/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+dist: trusty
+language: go
+go:
+  - 1.5
+  - tip
+script:
+  - make test

--- a/vendor/github.com/achanda/go-sysctl/LICENSE
+++ b/vendor/github.com/achanda/go-sysctl/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/achanda/go-sysctl/Makefile
+++ b/vendor/github.com/achanda/go-sysctl/Makefile
@@ -1,0 +1,8 @@
+PACKAGES = $(shell go list ./...)
+VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods \
+         -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
+
+all:	test
+
+test:
+	@go test ./...

--- a/vendor/github.com/achanda/go-sysctl/README.md
+++ b/vendor/github.com/achanda/go-sysctl/README.md
@@ -1,0 +1,2 @@
+# go-sysctl
+A package to work with sysctl keys in golang

--- a/vendor/github.com/achanda/go-sysctl/sysctl.go
+++ b/vendor/github.com/achanda/go-sysctl/sysctl.go
@@ -1,0 +1,36 @@
+package sysctl
+
+import (
+        "errors"
+        "io/ioutil"
+        "os"
+        "runtime"
+        "strings"
+)
+
+const (
+        sysctlDir = "/proc/sys/"
+)
+
+var invalidKeyError = errors.New("could not find the given key")
+
+func Get(name string) (string, error) {
+        if runtime.GOOS != "linux" {
+                os.Exit(1)
+        }
+        path := sysctlDir + strings.Replace(name, ".", "/", -1)
+        data, err := ioutil.ReadFile(path)
+        if err != nil {
+                return "",invalidKeyError
+        }
+        return strings.TrimSpace(string(data)),nil
+}
+
+func Set(name string, value string) error {
+        if runtime.GOOS != "linux" {
+                os.Exit(1)
+        }
+        path := sysctlDir + strings.Replace(name, ".", "/", -1)
+        err := ioutil.WriteFile(path, []byte(value), 0644)
+        return err
+}


### PR DESCRIPTION
* Collect the range values from `net.ipv4.ip_local_port_range` sysctl parameter
* If above is successful, all service ports of each service are checked to ensure they do not fall into this range
* Services that define a service port (at least one) within the range will be skipped and not configured