### PR TITLE
Support loadBalancerIP field from load balancer services

### DIFF
--- a/examples/haproxy-docker-wrapper/entrypoint.sh
+++ b/examples/haproxy-docker-wrapper/entrypoint.sh
@@ -23,4 +23,4 @@ sed -i $TEMPLATE \
 	-e "s/__HAPROXY_TIMEOUT_TUNNEL__/$HAPROXY_TIMEOUT_TUNNEL/" \
 	-e "s/__SYSLOG__/$SYSLOG/"
 
-exec kube2lb -apiserver="$APISERVER" -kubecfg="$KUBECFG" -template="$TEMPLATE" -server-name-templates="$SERVER_NAME_TEMPLATES" -config="$CONFFILE" -domain="$DOMAIN" -notify=command:"curl -s http://$HAPROXY_WRAPPER_CONTROL/reload"
+exec kube2lb -apiserver="$APISERVER" -kubecfg="$KUBECFG" -template="$TEMPLATE" -server-name-templates="$SERVER_NAME_TEMPLATES" -config="$CONFFILE" -domain="$DOMAIN" -default-lb-ip="$DEFAULT_LB_IP" -notify=command:"curl -s http://$HAPROXY_WRAPPER_CONTROL/reload"

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -214,7 +214,7 @@ func (c *KubernetesClient) getServices() ([]ServiceInformation, error) {
 				continue
 			}
 
-			err := ephemeralPortsRange.ValidateService(s)
+			err := ValidateService(s)
 			if err != nil {
 				log.Printf("Service validation failed: %s", err)
 				break
@@ -223,11 +223,6 @@ func (c *KubernetesClient) getServices() ([]ServiceInformation, error) {
 			parsedLBIP := net.ParseIP(defaultLBIP)
 			if s.Spec.Type == v1.ServiceTypeLoadBalancer && s.Spec.LoadBalancerIP != "" {
 				parsedLBIP = net.ParseIP(s.Spec.LoadBalancerIP)
-				if parsedLBIP == nil {
-					log.Printf("Couldn't parse IP '%s' for service %s in %s",
-						s.Spec.LoadBalancerIP, s.Name, s.Namespace)
-					break
-				}
 			}
 
 			for _, port := range s.Spec.Ports {

--- a/sanitychecks.go
+++ b/sanitychecks.go
@@ -19,13 +19,18 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
+	"time"
 
 	"github.com/achanda/go-sysctl"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
 const (
+	addressesExpiration = 5 * time.Second
+
 	ephemeralPortsRangeSysKey = "net.ipv4.ip_local_port_range"
+	nonLocalBindSysKey        = "net.ipv4.ip_nonlocal_bind"
 )
 
 type ServiceValidator interface {
@@ -33,8 +38,17 @@ type ServiceValidator interface {
 }
 
 var (
-	ephemeralPortsRange *EphemeralPortsRange
+	sanityChecks []ServiceValidator
 )
+
+func ValidateService(s *v1.Service) error {
+	for _, check := range sanityChecks {
+		if err := check.ValidateService(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 type EphemeralPortsRange struct {
 	check    bool
@@ -57,7 +71,7 @@ func (r EphemeralPortsRange) ValidateService(s *v1.Service) error {
 	for _, port := range s.Spec.Ports {
 		// Port found in range
 		if (port.Port >= r.LowPort) && (port.Port <= r.HighPort) {
-			return fmt.Errorf("Service %s in %s Service Port %d is in the ephemral ports range (%s), skipping it. Please check your configuration!", s.Name, s.Namespace, port.Port, r)
+			return fmt.Errorf("service %s in %s Service Port %d is in the ephemeral ports range (%s), skipping it. Please check your configuration!", s.Name, s.Namespace, port.Port, r)
 		}
 	}
 	// None of the ports in range
@@ -78,5 +92,68 @@ func initEphemeralPortsRangeCheck() *EphemeralPortsRange {
 }
 
 func init() {
-	ephemeralPortsRange = initEphemeralPortsRangeCheck()
+	sanityChecks = append(sanityChecks, initEphemeralPortsRangeCheck())
+}
+
+type AddressForLoadBalancerIP struct {
+	checkLocalBind     bool
+	interfaceAddresses []net.Addr
+	addressesTime      time.Time
+}
+
+func (a *AddressForLoadBalancerIP) addresses() ([]net.Addr, error) {
+	if a.addressesTime.IsZero() || time.Since(a.addressesTime) > addressesExpiration {
+		addresses, err := net.InterfaceAddrs()
+		if err != nil {
+			return nil, err
+		}
+		a.addressesTime = time.Now()
+		a.interfaceAddresses = addresses
+	}
+	return a.interfaceAddresses, nil
+}
+
+func (a AddressForLoadBalancerIP) ValidateService(s *v1.Service) error {
+	if s.Spec.Type != v1.ServiceTypeLoadBalancer || s.Spec.LoadBalancerIP == "" {
+		return nil
+	}
+
+	ip := net.ParseIP(s.Spec.LoadBalancerIP)
+	if ip == nil {
+		return fmt.Errorf("couldn't parse IP '%s' for service %s in %s",
+			s.Spec.LoadBalancerIP, s.Name, s.Namespace)
+	}
+
+	if a.checkLocalBind {
+		addrs, err := a.addresses()
+		if err != nil {
+			log.Printf("Error obtaining local interface addresses: %s", err)
+			return nil
+		}
+		for _, addr := range addrs {
+			switch addr := addr.(type) {
+			case *net.IPNet:
+				if addr.IP.Equal(ip) {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("service %s in %s cannot be bound to address %s defined in load balancer IP, skipping it. Please check your configuration!", s.Name, s.Namespace, s.Spec.LoadBalancerIP)
+	}
+
+	return nil
+}
+
+func initAddressForLoadBalancerIPCheck() *AddressForLoadBalancerIP {
+	nonLocalBind, err := sysctl.Get(nonLocalBindSysKey)
+	if err != nil {
+		log.Printf("Error reading %s from sysctl: %s, skipping load balancer IP checks", nonLocalBindSysKey, err)
+		return &AddressForLoadBalancerIP{checkLocalBind: false}
+	}
+
+	return &AddressForLoadBalancerIP{checkLocalBind: nonLocalBind == "0"}
+}
+
+func init() {
+	sanityChecks = append(sanityChecks, initAddressForLoadBalancerIPCheck())
 }

--- a/templates.go
+++ b/templates.go
@@ -18,8 +18,10 @@ package main
 
 import (
 	"bytes"
+	"encoding/hex"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -69,13 +71,22 @@ func initServerNameTemplates() (err error) {
 }
 
 type PortSpec struct {
+	IP       net.IP
 	Port     int32
 	Mode     string
 	Protocol string
 }
 
+// String representation of a PortSpec, intended to be used as config label
 func (s PortSpec) String() string {
-	return fmt.Sprintf("%d_%s_%s", s.Port, s.Protocol, s.Mode)
+	var encodedIP string
+	if s.IP.To4() != nil {
+		// No need to use more than 4 bytes if it is an IPv4 address
+		encodedIP = hex.EncodeToString(s.IP.To4())
+	} else {
+		encodedIP = hex.EncodeToString(s.IP)
+	}
+	return fmt.Sprintf("%s_%d_%s_%s", encodedIP, s.Port, s.Protocol, s.Mode)
 }
 
 type ServiceInformation struct {
@@ -86,6 +97,12 @@ type ServiceInformation struct {
 	NodePort  int32
 	External  []string
 	Timeout   int
+}
+
+// String representation of a Service, intended to be used as config label
+func (s ServiceInformation) String() string {
+	return fmt.Sprintf("%s_%s_%d_%s_%s",
+		s.Name, s.Namespace, s.Port.Port, s.Port.Protocol, s.Port.Mode)
 }
 
 type ClusterInformation struct {


### PR DESCRIPTION
With this change, kube2lb interprets the loadBalancerIP field of Services of type load balancer, and sets this IP in the PortSpec of the service so it can be used to generate configuration per IP.

Fixes #22 