### PR TITLE
Removed execution mode from haproxy template

### DIFF
--- a/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
+++ b/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
@@ -4,7 +4,6 @@
 global
 	log __SYSLOG__   local0 notice
 	maxconn __HAPROXY_MAXCONN__
-	daemon
 {{- if gt __HAPROXY_NBPROC__ 1 }}
 	nbproc __HAPROXY_NBPROC__
 {{- range $, $i := IntRange __HAPROXY_NBPROC__ 1 1 }}


### PR DESCRIPTION
As it is redundant with haproxy -D/-W flags (see https://github.com/tuenti/haproxy-docker-wrapper/pull/2)