### PR TITLE
Add a timeout for update notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ install:
   - export PATH="${TRAVIS_BUILD_DIR}/vendor/bin:$PATH"
 
 script:
-  - go build
-  - go test .
+  - go build -race
+  - go test . -race

--- a/kube2lb.go
+++ b/kube2lb.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -73,7 +74,7 @@ func main() {
 	client.AddTemplate(NewTemplate(templatePath, configPath))
 	client.AddNotifier(notifier)
 
-	if err := client.Watch(); err != nil {
+	if err := client.Watch(context.Background()); err != nil {
 		log.Fatalf("Couldn't watch Kubernetes API server: %s", err)
 	}
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -84,7 +84,7 @@ type dummyUpdater struct {
 	F        UpdaterFunc
 }
 
-func (dummyUpdater) Run(ctx context.Context) {
+func (*dummyUpdater) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 

--- a/updater.go
+++ b/updater.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
-	"log"
 	"sync/atomic"
 	"time"
 )
@@ -30,11 +30,11 @@ func init() {
 }
 
 type Updater interface {
-	Run()
+	Run(context.Context)
 	Signal()
 }
 
-type UpdaterFunc func()
+type UpdaterFunc func(context.Context)
 
 type UpdaterBuilder func(f UpdaterFunc) Updater
 
@@ -54,7 +54,7 @@ func NewUpdater(f UpdaterFunc) Updater {
 	return &u
 }
 
-func (u *antiBurstUpdater) antiBurst() {
+func (u *antiBurstUpdater) antiBurst(ctx context.Context) {
 	for {
 		select {
 		case <-u.burst:
@@ -62,26 +62,27 @@ func (u *antiBurstUpdater) antiBurst() {
 			if u.updateNeeded.Load().(int) == 1 {
 				u.signal <- struct{}{}
 			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }
 
-func (u *antiBurstUpdater) Run() {
-	go u.antiBurst()
-	for _ = range u.signal {
+func (u *antiBurstUpdater) Run(ctx context.Context) {
+	go u.antiBurst(ctx)
+	for {
+		select {
+		case <-u.signal:
+		case <-ctx.Done():
+			return
+		}
+
 		u.updateNeeded.Store(0)
 
-		c := make(chan struct{}, 1)
-		go func() {
-			u.f()
-			c <- struct{}{}
-		}()
-
-		select {
-		case <-c:
-		case <-time.After(time.Duration(updateTimeout) * time.Second):
-			log.Println("Update timed out")
-		}
+		timeout := time.Duration(updateTimeout) * time.Second
+		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+		u.f(timeoutCtx)
+		cancel()
 	}
 }
 

--- a/updater.go
+++ b/updater.go
@@ -17,9 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+	"log"
 	"sync/atomic"
 	"time"
 )
+
+var updateTimeout float64
+
+func init() {
+	flag.Float64Var(&updateTimeout, "update-timeout", 10, "Update timeout in seconds")
+}
 
 type Updater interface {
 	Run()
@@ -62,7 +70,18 @@ func (u *antiBurstUpdater) Run() {
 	go u.antiBurst()
 	for _ = range u.signal {
 		u.updateNeeded.Store(0)
-		u.f()
+
+		c := make(chan struct{}, 1)
+		go func() {
+			u.f()
+			c <- struct{}{}
+		}()
+
+		select {
+		case <-c:
+		case <-time.After(time.Duration(updateTimeout) * time.Second):
+			log.Println("Update timed out")
+		}
 	}
 }
 


### PR DESCRIPTION
Update notifications can hang forever, add a timeout to these operations. This also adds a `-update-timeout` flag to specify the timeout in seconds.

Background operations use now a context so we can control when they finish.