### PR TITLE
Add hatop package into example Dockerfile

### DIFF
--- a/examples/haproxy-docker-wrapper/Dockerfile
+++ b/examples/haproxy-docker-wrapper/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 MAINTAINER Jaime Soriano Pastor <jsoriano@tuenti.com>
 
 RUN apt-get update && \
-	apt-get install -y curl && \
+	apt-get install -y curl hatop && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY haproxy.cfg.tpl /etc/kube2lb/haproxy.cfg.tpl


### PR DESCRIPTION
Add hatop package into the Dockerfile example for haproxy.