### PR TITLE
enable seamless reload; makes Makefile work on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ all:
 release:
 	@if echo $(VERSION) | grep -q "dev$$" ; then echo Set VERSION variable to release; exit 1; fi
 	@if git show v$(VERSION) > /dev/null 2>&1; then echo Version $(VERSION) already exists; exit 1; fi
-	sed -i "s/^VERSION :=.*/VERSION := $(VERSION)/" Makefile
+	sed -i '' "s/^VERSION :=.*/VERSION := $(VERSION)/" Makefile
 	git ci Makefile -m "Version $(VERSION)"
 	git tag v$(VERSION) -a -m "Version $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION := 2.3.1
 PACKAGE := github.com/tuenti/kube2lb
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 GOLANG_DOCKER := golang:1.9.0
+TEMPFILE := $(shell mktemp)
 
 all:
 	docker run -v $(ROOT_DIR):/go/src/$(PACKAGE) -w /go/src/$(PACKAGE) -it --rm $(GOLANG_DOCKER) go build -ldflags "-X main.version=$(VERSION)"
@@ -9,6 +10,6 @@ all:
 release:
 	@if echo $(VERSION) | grep -q "dev$$" ; then echo Set VERSION variable to release; exit 1; fi
 	@if git show v$(VERSION) > /dev/null 2>&1; then echo Version $(VERSION) already exists; exit 1; fi
-	sed -i '' "s/^VERSION :=.*/VERSION := $(VERSION)/" Makefile
+	sed -e "s/^VERSION :=.*/VERSION := $(VERSION)/" Makefile > $(TEMPFILE) && mv $(TEMPFILE) > Makefile
 	git ci Makefile -m "Version $(VERSION)"
 	git tag v$(VERSION) -a -m "Version $(VERSION)"

--- a/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
+++ b/examples/haproxy-docker-wrapper/haproxy.cfg.tpl
@@ -10,7 +10,7 @@ global
 	nbthread {{ $nbthread }}
 {{- range $i, $cpu := IntRange $nbproc 1 $nbthread }}
 	cpu-map auto:{{ Add $i 1 }}/1-{{ $nbthread }} {{ $cpu }}-{{ Add $cpu $nbthread -1 }}
-	stats socket /var/lib/haproxy/socket{{ Add $i 1 }} process {{ Add $i 1 }} mode 600 level admin
+	stats socket /var/lib/haproxy/socket{{ Add $i 1 }} expose-fd listeners process {{ Add $i 1 }} mode 600 level admin
 {{- end }}
 
 


### PR DESCRIPTION
adds `expose-fd listeners` to config so that we enable seamless reloads. It may fix FD limits problems and reloads issues we have been expecting since upgrading to 1.8